### PR TITLE
Protect sensitive nomad config files

### DIFF
--- a/libraries/resources.rb
+++ b/libraries/resources.rb
@@ -210,6 +210,8 @@ class Chef::Provider
 
         f = file ::File.join(r.path, "#{r.prefix}_#{r.name}.hcl") do
           content r.to_json
+          sensitive true
+          mode 0640
           action a
         end
 


### PR DESCRIPTION
Many of these config files contain secrets, and the default mode is
world readable. Mark all as sensitive, and not world readable.

It would be nice to see configurable user in this cookbook, but since
everything currently is installed and run as root, user/group
considerations are out of scope for this particular change.

Currently, sensitive data is being leaked to chef output and logs