### PR TITLE
Remove Atlas configuration from defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Downloads and installs nomad from the URL specified in `attributes/install.rb`.
 nomad::configure
 ----------------
 Sets up minimal default configuration (controlled by `attributes/configure.rb`
-using the provided resources for global, server, client, and atlas
-configuration blocks.
+using the provided resources for global, server, and client, configuration
+blocks.
 
 nomad::manage
 -------------
@@ -90,16 +90,6 @@ nomad\_client\_config
 |max_kill_timeout|String|
 |no_host_uuid|[TrueClass, FalseClass]|
 |reserved|Hash|
-
-nomad\_atlas\_config
---------------------
-
-|attribute|kind_of|
-|---------|-------|
-|infrastructure|String|
-|token|String|
-|join|[TrueClass, FalseClass]|
-|endpoint|String|
 
 nomad\_consul\_config
 ---------------------

--- a/attributes/configure.rb
+++ b/attributes/configure.rb
@@ -19,8 +19,6 @@
 default['nomad'].tap do |nomad|
   nomad['data_dir'] = '/var/lib/nomad'
 
-  nomad['atlas_join'] = false
-
   nomad['client_enabled'] = true
   nomad['server_enabled'] = false
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -31,5 +31,5 @@ nomad_client_config '00-default' do
 end
 
 nomad_atlas_config '00-default' do
-  join nomad['atlas_join']
+  action :delete
 end

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -37,10 +37,6 @@ describe 'nomad::configure' do
       expect(chef_run).to create_nomad_client_config('00-default').with(
         enabled: true
       )
-
-      expect(chef_run).to create_nomad_atlas_config('00-default').with(
-        join: false
-      )
     end
 
     it 'converges successfully' do

--- a/test/integration/default/serverspec/configure_spec.rb
+++ b/test/integration/default/serverspec/configure_spec.rb
@@ -13,10 +13,6 @@ describe 'nomad::configure' do
     its(:content) { should match /enabled/ }
   end
 
-  describe file('/etc/nomad-conf.d/atlas_00-default.hcl') do
-    its(:content) { should match /join/ }
-  end
-
   describe file('/etc/nomad-conf.d/consul_test.hcl') do
     its(:content) { should match /false/ }
   end


### PR DESCRIPTION
Nomad 0.7.1 removes the "atlas" configuration section. Nomad will fail to start if this section is present, because it no longer recognizes the key. This patch no longer creates the file, and removes it if present.

I didn't completely remove the `nomad_atlas_config` LWRP so that people still using it won't be broken by this change.

Unfortunately, I don't know ChefSpec well enough to figure out how to update the integration tests to verify that the config file is removed by default. All the examples in the cookbook right now are testing properties of a resource that exists, and what I want to do is something more like `expect(chef_run).to delete_file(...)`, but there doesn't seem to be a `chef_run` in the integration test context. I'd be happy to add that as another commit if you can give me a hint how it's done.

Might also be wise to upgrade the default version of Nomad installed to 0.7.1 before cutting another release, though I did not do that in this patch.