### PR TITLE
support running nomad with environment variables, to support aws creds

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,8 @@ default['nomad'].tap do |nomad|
     args['config'] = NomadCookbook::Helpers::CONFIG_ROOT
   end
 
+  nomad['environment'] = {}
+
   nomad['source_url'] = 'https://releases.hashicorp.com/nomad'
   nomad['package'], nomad['checksum'] =
     case node['os']

--- a/templates/default/upstart.conf.erb
+++ b/templates/default/upstart.conf.erb
@@ -12,5 +12,12 @@ stop on runlevel [016]
 # Automatically restart if crashed
 respawn
 
+<% if !@environment.empty? %>
+# Set environment variables for the service
+  <%- @environment.each do |k, v| %>
+env <%= @k %>=<%= @v %>
+  <%- end %>
+
+<% end %>
 # Start the process
 exec /usr/local/sbin/nomad agent <%= @daemon_args %>

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -5,5 +5,7 @@ default['nomad'].tap do |nomad|
     da['network-interface'] = node['network']['default_interface']
   end
 
+  nomad['environment'] = { FOO: 'OOF', BAR: 'RAB' }
+
   nomad['agent']['name'] = 'nomad-test'
 end

--- a/test/integration/default/recipes_spec.rb
+++ b/test/integration/default/recipes_spec.rb
@@ -27,4 +27,9 @@ control 'manage' do
     it { should be_enabled }
     it { should be_running }
   end
+
+  describe bash('cat /proc/$(systemctl show -p MainPID nomad|cut -d = -f 2)/environ|tr "\0" "\n"') do
+    its('stdout') { should match /FOO\s*=\s*OOF/ }
+    its('stdout') { should match /BAR\s*=\s*RAB/ }
+  end
 end


### PR DESCRIPTION
Nomad has the artifact stanza in job files, which allows downloading files from s3 among others. This is implemented with the go-getter library which supports the standard environment variables for AWS credentials.

This PR enables adding environment variables to the nomad processes so these credentials can be configured at the server level.